### PR TITLE
do not crash on unicode decode errors

### DIFF
--- a/pyxtermjs/app.py
+++ b/pyxtermjs/app.py
@@ -38,7 +38,7 @@ def read_and_forward_pty_output():
             timeout_sec = 0
             (data_ready, _, _) = select.select([app.config["fd"]], [], [], timeout_sec)
             if data_ready:
-                output = os.read(app.config["fd"], max_read_bytes).decode()
+                output = os.read(app.config["fd"], max_read_bytes).decode(errors='ignore')
                 socketio.emit("pty-output", {"output": output}, namespace="/pty")
 
 


### PR DESCRIPTION
Some programs e.g. pip in versions 21.X emit non strictly output unicode.

This means that running pip install something in pyxtermjs crashes pyxtermjs due to a unicode error, if there is a long progress bar:

To reproduce, inside pyxtermjs do:

```
python3 -mvenv venv
source venv/bin/activate
pip install -U pip==21.*
pip install torch
```

pyxtermjs crashes with:

```
line 41, in read_and_forward_pty_output
    output = os.read(app.config["fd"], max_read_bytes).decode()
UnicodeDecodeError: 'utf-8' codec can't decode byte 0xe2 in position 4094: unexpected end of data
```


After this change - the above works.
